### PR TITLE
Add three-node web-search flow example

### DIFF
--- a/cookbook/three-node-example/flow.py
+++ b/cookbook/three-node-example/flow.py
@@ -1,0 +1,15 @@
+from pocketflow import Flow
+from nodes import DecideNode, SearchWebNode, AnswerNode
+
+
+def create_flow() -> Flow:
+    """Assemble the three-node flow."""
+    decide = DecideNode()
+    search = SearchWebNode()
+    answer = AnswerNode()
+
+    decide - "search" >> search
+    decide - "answer" >> answer
+    search - "decide" >> decide
+
+    return Flow(start=decide)

--- a/cookbook/three-node-example/main.py
+++ b/cookbook/three-node-example/main.py
@@ -1,0 +1,20 @@
+import sys
+from flow import create_flow
+
+
+def main():
+    question = "Who won the Nobel Prize in Physics 2024?"
+    for arg in sys.argv[1:]:
+        if arg.startswith("--"):
+            question = arg[2:]
+            break
+
+    pipeline = create_flow()
+    shared = {"question": question}
+    print(f"Processing question: {question}")
+    pipeline.run(shared)
+    print("\nFinal Answer:\n" + shared.get("answer", "No answer"))
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/three-node-example/nodes.py
+++ b/cookbook/three-node-example/nodes.py
@@ -1,0 +1,76 @@
+from pocketflow import Node
+import yaml
+
+from utils import call_llm, search_duckduckgo
+
+class DecideNode(Node):
+    """Decide whether to search the web or answer directly."""
+    def prep(self, shared):
+        question = shared["question"]
+        context = shared.get("context", "No previous search")
+        prompt = f"""
+### CONTEXT
+Question: {question}
+Previous Research: {context}
+
+### ACTION SPACE
+- search: Look up more information on the web
+- answer: Provide a final answer with current context
+
+Return your response in this YAML format:
+```yaml
+action: search | answer
+reason: <why>
+search_query: <query if searching>
+answer: <answer if answering>
+```
+"""
+        return prompt
+
+    def exec(self, prompt):
+        response = call_llm(prompt)
+        try:
+            yaml_str = response.split("```yaml")[1].split("```", 1)[0]
+            decision = yaml.safe_load(yaml_str)
+        except Exception:
+            decision = {"action": "answer", "answer": response}
+        return decision
+
+    def post(self, shared, prep_res, decision):
+        if decision.get("action") == "search":
+            shared["search_query"] = decision.get("search_query", shared["question"])
+            return "search"
+        shared["answer"] = decision.get("answer", "")
+        return "answer"
+
+class SearchWebNode(Node):
+    """Search the web using DuckDuckGo."""
+    def prep(self, shared):
+        return shared.get("search_query", shared["question"])
+
+    def exec(self, query):
+        return search_duckduckgo(query)
+
+    def post(self, shared, prep_res, results):
+        shared["context"] = results
+        return "decide"
+
+class AnswerNode(Node):
+    """Use the context to craft a final answer via OpenAI."""
+    def prep(self, shared):
+        question = shared["question"]
+        context = shared.get("context", "")
+        prompt = f"""
+### CONTEXT
+Question: {question}
+Research: {context}
+
+Provide a comprehensive answer."""
+        return prompt
+
+    def exec(self, prompt):
+        return call_llm(prompt)
+
+    def post(self, shared, prep_res, answer):
+        shared["answer"] = answer
+        return "done"

--- a/cookbook/three-node-example/utils.py
+++ b/cookbook/three-node-example/utils.py
@@ -1,0 +1,19 @@
+from openai import OpenAI
+import os
+from duckduckgo_search import DDGS
+
+def call_llm(prompt: str) -> str:
+    """Call OpenAI chat completion API."""
+    client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY", "your-api-key"))
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return response.choices[0].message.content
+
+def search_duckduckgo(query: str) -> str:
+    """Search the web using DuckDuckGo and return formatted results."""
+    results = DDGS().text(query, max_results=5)
+    return "\n\n".join(
+        f"Title: {r['title']}\nURL: {r['href']}\nSnippet: {r['body']}" for r in results
+    )


### PR DESCRIPTION
## Summary
- add a cookbook example demonstrating a 3-node flow
- nodes: `DecideNode`, `SearchWebNode`, `AnswerNode`
- utilities for OpenAI calls and DuckDuckGo search
- script to run the flow with a sample question

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686964fceb248333b8a3f07f6de01517